### PR TITLE
Example of using sandbox vs prod

### DIFF
--- a/Python/CreateHitSample.py
+++ b/Python/CreateHitSample.py
@@ -12,62 +12,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import boto3
 
-# Before connecting to MTurk, set up your AWS account and IAM settings as described here:
+# Before connecting to MTurk, set up your AWS account and IAM settings as
+# described here:
 # https://blog.mturk.com/how-to-use-iam-to-control-api-access-to-your-mturk-account-76fe2c2e66e2
 #
 # Follow AWS best practices for setting up credentials here:
-# http://boto3.readthedocs.io/en/latest/guide/configuration.html 
+# http://boto3.readthedocs.io/en/latest/guide/configuration.html
 
-# Use the Amazon Mechanical Turk Sandbox to publish test Human Intelligence Tasks (HITs) without paying any money.
-# Sign up for a Sandbox account at https://requestersandbox.mturk.com/ with the same credentials as your main MTurk account.
-client = boto3.client(
-    service_name = 'mturk', 
-    endpoint_url = 'https://mturk-requester-sandbox.us-east-1.amazonaws.com'
+# Use the Amazon Mechanical Turk Sandbox to publish test Human Intelligence
+# Tasks (HITs) without paying any money.  Sign up for a Sandbox account at
+# https://requestersandbox.mturk.com/ with the same credentials as your main
+# MTurk account.
+
+# By default, HITs are created in the free-to-use Sandbox
+create_hits_in_live = False
+
+environments = {
+        "live": {
+            "endpoint": "https://mturk-requester.us-east-1.amazonaws.com",
+            "preview": "https://www.mturk.com/mturk/preview",
+            "manage": "https://requester.mturk.com/mturk/manageHITs",
+            "reward": "0.20"
+        },
+        "sandbox": {
+            "endpoint": "https://mturk-requester-sandbox.us-east-1.amazonaws.com",
+            "preview": "https://workersandbox.mturk.com/mturk/preview",
+            "manage": "https://requestersandbox.mturk.com/mturk/manageHITs",
+            "reward": "0.20"
+        },
+}
+mturk_environment = environments["live"] if create_hits_in_live else environments["sandbox"]
+
+# use profile if one was passed as an arg, otherwise
+profile_name = sys.argv[1] if len(sys.argv) >= 2 else None
+session = boto3.Session(profile_name=profile_name)
+client = session.client(
+    service_name='mturk',
+    region_name='us-east-1',
+    endpoint_url=mturk_environment['endpoint'],
 )
-
-# Uncomment the below to connect to the live marketplace
-# Region is always us-east-1
-# client = boto3.client(service_name = 'mturk', region_name='us-east-1')
 
 # Test that you can connect to the API by checking your account balance
 user_balance = client.get_account_balance()
 
-# In Sandbox this always returns $10,000
+# In Sandbox this always returns $10,000. In live, it will be your acutal balance.
 print "Your account balance is {}".format(user_balance['AvailableBalance'])
 
+# The question we ask the workers is contained in this file.
 questionSampleFile = open("my_question.xml", "r")
 questionSample = questionSampleFile.read()
 
-# Create a qualification with Locale In('US', 'CA') requirement attached
-localRequirements = [{
-    'QualificationTypeId': '00000000000000000071',
-    'Comparator': 'In',
-    'LocaleValues': [{
-        'Country': 'US'
-    }, {
-        'Country': 'CA'
-    }],
-    'RequiredToPreview': True
+# Example of using qualification to restrict responses to Workers who have had
+# at least 80% of their assignments approved. See:
+# http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_QualificationRequirementDataStructureArticle.html#ApiReference_QualificationType-IDs
+workerRequirements = [{
+    'QualificationTypeId': '000000000000000000L0',
+    'Comparator': 'GreaterThanOrEqualTo',
+    'IntegerValues': [80],
+    'RequiredToPreview': True,
 }]
 
-# Create the HIT 
+# Create the HIT
 response = client.create_hit(
-    MaxAssignments = 10,
-    LifetimeInSeconds = 600,
-    AssignmentDurationInSeconds = 600,
-    Reward ='0.20',
-    Title = 'Answer a simple question',
-    Keywords = 'question, answer, research',
-    Description = 'Answer a simple question',
-    Question = questionSample,
-    QualificationRequirements = localRequirements
+    MaxAssignments=3,
+    LifetimeInSeconds=600,
+    AssignmentDurationInSeconds=600,
+    Reward=mturk_environment['reward'],
+    Title='Answer a simple question',
+    Keywords='question, answer, research',
+    Description='Answer a simple question. Created from mturk-code-samples.',
+    Question=questionSample,
+    QualificationRequirements=workerRequirements,
 )
 
 # The response included several fields that will be helpful later
 hit_type_id = response['HIT']['HITTypeId']
 hit_id = response['HIT']['HITId']
-print "Your HIT has been created. You can see it at this link:"
-print "https://workersandbox.mturk.com/mturk/preview?groupId={}".format(hit_type_id)
-print "Your HIT ID is: {}".format(hit_id)
+print "\nCreated HIT: {}".format(hit_id)
+
+print "\nYou can work the HIT here:"
+print mturk_environment['preview'] + "?/groupId={}".format(hit_type_id)
+
+print "\nAnd see results here:"
+print mturk_environment['manage']

--- a/Python/CreateHitSample.py
+++ b/Python/CreateHitSample.py
@@ -35,13 +35,13 @@ environments = {
             "endpoint": "https://mturk-requester.us-east-1.amazonaws.com",
             "preview": "https://www.mturk.com/mturk/preview",
             "manage": "https://requester.mturk.com/mturk/manageHITs",
-            "reward": "0.20"
+            "reward": "0.00"
         },
         "sandbox": {
             "endpoint": "https://mturk-requester-sandbox.us-east-1.amazonaws.com",
             "preview": "https://workersandbox.mturk.com/mturk/preview",
             "manage": "https://requestersandbox.mturk.com/mturk/manageHITs",
-            "reward": "0.20"
+            "reward": "0.11"
         },
 }
 mturk_environment = environments["live"] if create_hits_in_live else environments["sandbox"]
@@ -62,13 +62,12 @@ user_balance = client.get_account_balance()
 print "Your account balance is {}".format(user_balance['AvailableBalance'])
 
 # The question we ask the workers is contained in this file.
-questionSampleFile = open("my_question.xml", "r")
-questionSample = questionSampleFile.read()
+question_sample = open("my_question.xml", "r").read()
 
 # Example of using qualification to restrict responses to Workers who have had
 # at least 80% of their assignments approved. See:
 # http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_QualificationRequirementDataStructureArticle.html#ApiReference_QualificationType-IDs
-workerRequirements = [{
+worker_requirements = [{
     'QualificationTypeId': '000000000000000000L0',
     'Comparator': 'GreaterThanOrEqualTo',
     'IntegerValues': [80],
@@ -84,8 +83,8 @@ response = client.create_hit(
     Title='Answer a simple question',
     Keywords='question, answer, research',
     Description='Answer a simple question. Created from mturk-code-samples.',
-    Question=questionSample,
-    QualificationRequirements=workerRequirements,
+    Question=question_sample,
+    QualificationRequirements=worker_requirements,
 )
 
 # The response included several fields that will be helpful later
@@ -94,7 +93,7 @@ hit_id = response['HIT']['HITId']
 print "\nCreated HIT: {}".format(hit_id)
 
 print "\nYou can work the HIT here:"
-print mturk_environment['preview'] + "?/groupId={}".format(hit_type_id)
+print mturk_environment['preview'] + "?groupId={}".format(hit_type_id)
 
 print "\nAnd see results here:"
 print mturk_environment['manage']

--- a/Python/RetrieveAndApproveHitSample.py
+++ b/Python/RetrieveAndApproveHitSample.py
@@ -20,7 +20,7 @@ from xml.dom.minidom import parseString
 # https://blog.mturk.com/how-to-use-iam-to-control-api-access-to-your-mturk-account-76fe2c2e66e2
 #
 # Follow AWS best practices for setting up credentials here:
-# http://boto3.readthedocs.io/en/latest/guide/configuration.html 
+# http://boto3.readthedocs.io/en/latest/guide/configuration.html
 
 # Use the Amazon Mechanical Turk Sandbox to publish test Human Intelligence Tasks (HITs) without paying any money.
 # Sign up for a Sandbox account at https://requestersandbox.mturk.com/ with the same credentials as your main MTurk account.
@@ -64,15 +64,15 @@ hit = client.get_hit(HITId=hit_id)
 print 'Hit {} status: {}'.format(hit_id, hit['HIT']['HITStatus'])
 response = client.list_assignments_for_hit(
     HITId=hit_id,
-    AssignmentStatuses=['Submitted','Approved'], 
-    MaxResults=10
+    AssignmentStatuses=['Submitted', 'Approved'],
+    MaxResults=10,
 )
 
 assignments = response['Assignments']
 print 'The number of submitted assignments is {}'.format(len(assignments))
 for assignment in assignments:
-    WorkerId = assignment['WorkerId']
-    assignmentId = assignment['AssignmentId']
+    worker_id = assignment['WorkerId']
+    assignment_id = assignment['AssignmentId']
     answer_xml = parseString(assignment['Answer'])
 
     # the answer is an xml document. we pull out the value of the first
@@ -81,13 +81,13 @@ for assignment in assignments:
     # See https://stackoverflow.com/questions/317413
     only_answer = " ".join(t.nodeValue for t in answer.childNodes if t.nodeType == t.TEXT_NODE)
 
-    print 'The Worker with ID {} submitted assignment {} and gave the answer "{}"'.format(WorkerId,assignmentId, only_answer)
+    print 'The Worker with ID {} submitted assignment {} and gave the answer "{}"'.format(worker_id, assignment_id, only_answer)
 
     # Approve the Assignment (if it hasn't already been approved)
     if assignment['AssignmentStatus'] == 'Submitted':
-    	print 'Approving Assignment {}'.format(assignmentId)
-    	client.approve_assignment(
-            AssignmentId=assignmentId,
+        print 'Approving Assignment {}'.format(assignment_id)
+        client.approve_assignment(
+            AssignmentId=assignment_id,
             RequesterFeedback='good',
             OverrideRejection=False,
-    	)
+        )

--- a/Python/RetrieveAndApproveHitSample.py
+++ b/Python/RetrieveAndApproveHitSample.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import boto3
+from xml.dom.minidom import parseString
 
 # Before connecting to MTurk, set up your AWS account and IAM settings as described here:
 # https://blog.mturk.com/how-to-use-iam-to-control-api-access-to-your-mturk-account-76fe2c2e66e2
@@ -23,23 +25,46 @@ import boto3
 # Use the Amazon Mechanical Turk Sandbox to publish test Human Intelligence Tasks (HITs) without paying any money.
 # Sign up for a Sandbox account at https://requestersandbox.mturk.com/ with the same credentials as your main MTurk account.
 
-client = boto3.client(
-    service_name='mturk',
-    endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com'
-)
-
-# Uncomment the below to connect to the live marketplace
-# Region is always us-east-1
-# client = boto3.client(service_name = 'mturk', region_name='us-east-1')
-
 # This HIT id should be the HIT you just created - see the CreateHITSample.py file for generating a HIT
-hit_id = 'YOUR_HIT_ID'
+if(len(sys.argv) < 2):
+    print("You must pass a HIT id as the first argument")
+    sys.exit(-1)
+
+hit_id = sys.argv[1]
+
+# By default, we use the free-to-use Sandbox
+create_hits_in_live = False
+
+environments = {
+        "live": {
+            "endpoint": "https://mturk-requester.us-east-1.amazonaws.com",
+            "preview": "https://www.mturk.com/mturk/preview",
+            "manage": "https://requester.mturk.com/mturk/manageHITs",
+            "reward": "0.00"
+        },
+        "sandbox": {
+            "endpoint": "https://mturk-requester-sandbox.us-east-1.amazonaws.com",
+            "preview": "https://workersandbox.mturk.com/mturk/preview",
+            "manage": "https://requestersandbox.mturk.com/mturk/manageHITs",
+            "reward": "0.11"
+        },
+}
+mturk_environment = environments["live"] if create_hits_in_live else environments["sandbox"]
+
+# use profile if one was passed as an arg, otherwise
+profile_name = sys.argv[2] if len(sys.argv) >= 3 else None
+session = boto3.Session(profile_name=profile_name)
+client = session.client(
+    service_name='mturk',
+    region_name='us-east-1',
+    endpoint_url=mturk_environment['endpoint'],
+)
 
 hit = client.get_hit(HITId=hit_id)
 print 'Hit {} status: {}'.format(hit_id, hit['HIT']['HITStatus'])
 response = client.list_assignments_for_hit(
     HITId=hit_id,
-    AssignmentStatuses=['Submitted'], 
+    AssignmentStatuses=['Submitted','Approved'], 
     MaxResults=10
 )
 
@@ -48,13 +73,21 @@ print 'The number of submitted assignments is {}'.format(len(assignments))
 for assignment in assignments:
     WorkerId = assignment['WorkerId']
     assignmentId = assignment['AssignmentId']
-    answer = assignment['Answer']
-    print 'The Worker with ID {} submitted assignment {} and gave the answer {}'.format(WorkerId,assignmentId, answer)
+    answer_xml = parseString(assignment['Answer'])
 
-    # Approve the Assignment
-    print 'Approve Assignment {}'.format(assignmentId)
-    client.approve_assignment(
-        AssignmentId=assignmentId,
-        RequesterFeedback='good',
-        OverrideRejection=False
-    )
+    # the answer is an xml document. we pull out the value of the first
+    # //QuestionFormAnswers/Answer/FreeText
+    answer = answer_xml.getElementsByTagName('FreeText')[0]
+    # See https://stackoverflow.com/questions/317413
+    only_answer = " ".join(t.nodeValue for t in answer.childNodes if t.nodeType == t.TEXT_NODE)
+
+    print 'The Worker with ID {} submitted assignment {} and gave the answer "{}"'.format(WorkerId,assignmentId, only_answer)
+
+    # Approve the Assignment (if it hasn't already been approved)
+    if assignment['AssignmentStatus'] == 'Submitted':
+    	print 'Approving Assignment {}'.format(assignmentId)
+    	client.approve_assignment(
+            AssignmentId=assignmentId,
+            RequesterFeedback='good',
+            OverrideRejection=False,
+    	)


### PR DESCRIPTION
The sample can create HITs in sandbox or prod. 

It also takes an optional profile name as an arg, in case you use the AWS CLI extensively and have a lot of them.

Some style cleanups, too.